### PR TITLE
Fix share link URLs

### DIFF
--- a/layouts/partials/utils/share.html
+++ b/layouts/partials/utils/share.html
@@ -9,39 +9,39 @@
       {{- $tag_list = delimit . "," -}}
     {{- end -}}
     {{- partial "inline/share/item.html"
-      (dict 
-        "Name" "Reddit" 
+      (dict
+        "Name" "Reddit"
         "Icon" "reddit"
-        "Title" .Title 
-        "URL" "https://reddit.com/submit?url={{- .Permalink | relURL -}}&title={{- .Title -}}")
+        "Title" .Title
+        "URL" (fmt.Print "https://reddit.com/submit?url=" .Permalink "&title=" .Title ))
     -}}
     {{- partial "inline/share/item.html"
-      (dict 
-        "Name" "X.com" 
+      (dict
+        "Name" "X.com"
         "Icon" "twitter"
-        "Title" .Title 
-        "URL" "https://x.com/intent/tweet/?text={{- .Title -}}&amp;url={{- .Permalink | relURL -}}&amp;hashtags={{- $tag_list }}")
+        "Title" .Title
+        "URL" (fmt.Print "https://x.com/intent/tweet/?text=" .Title "&url= " .Permalink "&hashtags=" $tag_list))
     -}}
     {{- partial "inline/share/item.html"
-      (dict 
-        "Name" "Facebook" 
+      (dict
+        "Name" "Facebook"
         "Icon" "facebook"
-        "Title" .Title 
-        "URL" "https://facebook.com/sharer/sharer.php?u={{- .Permalink | relURL -}}")
+        "Title" .Title
+        "URL" (fmt.Print "https://facebook.com/sharer/sharer.php?u= " .Permalink ))
     -}}
     {{- partial "inline/share/item.html"
-      (dict 
-        "Name" "Google" 
+      (dict
+        "Name" "Google"
         "Icon" "google"
-        "Title" .Title 
-        "URL" "https://www.google.com/bookmarks/mark?op=edit&bkmk={{- .Permalink | relURL -}}&title={{- .Title -}}")
+        "Title" .Title
+        "URL" (fmt.Print "https://www.google.com/bookmarks/mark?op=edit&bkmk=" .Permalink "&title=" .Title ))
     -}}
     {{- partial "inline/share/item.html"
-      (dict 
-        "Name" "Telegram" 
+      (dict
+        "Name" "Telegram"
         "Icon" "telegram"
-        "Title" .Title 
-        "URL" "https://telegram.me/share/url?url={{- .Permalink | relURL -}}&text={{- .Title -}}")
+        "Title" .Title
+        "URL" (fmt.Print "https://telegram.me/share/url?url=" .Permalink "&text=" .Title ))
     -}}
   </div>
 </div>


### PR DESCRIPTION
Resolves #4 

I've not been able to test all due to not having accounts, but the URLs all look to be correct now.

Apologies for the whitespace changes, my editor is trimming whitespace.