### PR TITLE
Fix display of terms when multiple are assigned to a page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -439,7 +439,7 @@ body {
   }
 
   .fluidity-page-title-line {
-    @apply absolute -bottom-1 left-0 right-0 h-0.5 
+    @apply absolute -bottom-1 left-0 right-0 h-0.5
            bg-gradient-to-r from-sky-400 to-blue-500 dark:from-sky-500 dark:to-blue-400
            transform origin-left scale-x-0 group-hover:scale-x-100
            transition-transform duration-300 ease-out;
@@ -455,7 +455,7 @@ body {
 
   .fluidity-tag {
     @apply rounded-md px-2 py-0.5 text-sm
-           bg-blue-50/90 dark:bg-blue-900/30 
+           bg-blue-50/90 dark:bg-blue-900/30
            text-blue-600 dark:text-blue-300
            hover:bg-sky-50/90 dark:hover:bg-sky-900/30
            hover:text-sky-600 dark:hover:text-sky-300
@@ -465,9 +465,17 @@ body {
            transition-all duration-200;
   }
 
+  .fluidity-category {
+    @apply inline-flex py-1.5 px-1 text-sm
+      text-sky-700 dark:text-sky-300
+      underline underline-offset-4 decoration-sky-700
+      transform transition-all duration-300
+      group-hover:decoration-double;
+  }
+
   .fluidity-header-icon {
-       @apply p-2 rounded-lg text-sky-700 dark:text-sky-400 
-       hover:bg-sky-50 dark:hover:bg-sky-900/40 
+       @apply p-2 rounded-lg text-sky-700 dark:text-sky-400
+       hover:bg-sky-50 dark:hover:bg-sky-900/40
        transition-colors duration-200 cursor-pointer;
   }
 
@@ -476,9 +484,9 @@ body {
   }
 
   .fluidity-box-1 {
-    @apply bg-white/80 dark:bg-neutral-900/80 
+    @apply bg-white/80 dark:bg-neutral-900/80
     border border-neutral-400/80 dark:border-neutral-800/80
-    rounded-xl divide-y divide-blue-100 dark:divide-blue-900/50 
+    rounded-xl divide-y divide-blue-100 dark:divide-blue-900/50
     backdrop-blur-sm
     shadow-sm shadow-blue-100/50 dark:shadow-blue-900/30;
   }

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -101,6 +101,13 @@ params:
     list: 5
     archives: 20
 
+  # Customise list pages
+  listPage:
+    # The number of categories on a page to display in the list summary.
+    numCategoriesToShow: 1
+    # The number of tags on a page to deisplay in the list summary.
+    numTagsToShow: 3
+
   # Social links
   social:
     twitter: 'Your Twitter username'

--- a/layouts/partials/archive-article.html
+++ b/layouts/partials/archive-article.html
@@ -1,4 +1,8 @@
 {{- $article := . -}}
+{{/* 1000 is used to effectively display all */}}
+{{- $numCategoriesToShow := default 1000 .Site.Params.listPage.numCategoriesToShow -}}
+{{- $numTagsToShow := default 1000 .Site.Params.listPage.numTagsToShow -}}
+
 <div class="group relative">
   <a href="{{- .Permalink | relURL -}}" class="block relative">
     <div
@@ -29,7 +33,7 @@
             <!-- Categories -->
             {{- with $article.GetTerms "categories" -}}
               <div class="flex flex-wrap gap-2">
-                {{- range . -}}
+                {{- range (first $numCategoriesToShow .) -}}
                   <span
                     class="fluidity-category inline-flex items-center text-sm">
                     {{- .Title -}}
@@ -40,7 +44,7 @@
             <!-- Tags -->
             {{- with $article.GetTerms "tags" -}}
               <div class="flex flex-wrap gap-2">
-                {{- range . -}}
+                {{- range (first $numTagsToShow .) -}}
                   <span
                     class="fluidity-tag inline-flex items-center text-sm">
                     {{- .Title -}}

--- a/layouts/partials/archive-article.html
+++ b/layouts/partials/archive-article.html
@@ -27,8 +27,8 @@
           </h3>
           <div class="flex flex-col sm:flex-row items-start sm:items-center flex-wrap gap-x-3 gap-y-2">
             <!-- Categories -->
-            {{- with $article.Params.categories -}}
-              {{- range first 1 . -}}
+            {{- with $article.GetTerms "categories" -}}
+              {{- range . -}}
                 <span
                   class="
                   inline-flex py-1.5 px-1 text-sm
@@ -36,7 +36,7 @@
                   underline underline-offset-4 decoration-sky-700
                   transform transition-all duration-300
                   group-hover:decoration-double">
-                  {{- . -}}
+                  {{- .Title -}}
                 </span>
               {{- end -}}
             {{- end -}}

--- a/layouts/partials/archive-article.html
+++ b/layouts/partials/archive-article.html
@@ -29,6 +29,12 @@
             ">
             {{- .Title -}}
           </h3>
+          <div class="text-neutral-700 dark:text-neutral-300 leading-relaxed text-base">
+            {{- .Summary | plainify -}}
+            {{- if .Truncated -}}
+              <span class="hellip">&hellip;</span>
+            {{- end -}}
+          </div>
           <div class="flex flex-col sm:flex-row items-start sm:items-center flex-wrap gap-x-3 gap-y-2">
             <!-- Categories -->
             {{- with $article.GetTerms "categories" -}}

--- a/layouts/partials/archive-article.html
+++ b/layouts/partials/archive-article.html
@@ -3,13 +3,13 @@
   <a href="{{- .Permalink | relURL -}}" class="block relative">
     <div
       class="
-        px-4 py-2 lg:px-6 lg:py-4 
+        px-4 py-2 lg:px-6 lg:py-4
         border-b border-neutral-200/80 dark:border-neutral-800/80
         transition-all duration-300 ease-out
         hover:bg-gradient-to-r from-sky-50/50 via-blue-50/40 to-neutral-50/30
         dark:hover:bg-gradient-to-r dark:from-sky-900/30 dark:via-blue-900/20 dark:to-neutral-900/10
         last:border-b-0
-        before:absolute before:inset-0 
+        before:absolute before:inset-0
         before:bg-gradient-to-r before:from-transparent
         before:opacity-0 group-hover:before:opacity-100
         before:transition-all before:duration-500">
@@ -41,12 +41,12 @@
               {{- end -}}
             {{- end -}}
             <!-- Tags -->
-            {{- with $article.Params.tags -}}
+            {{- with $article.GetTerms "tags" -}}
               <div class="flex flex-wrap gap-2">
-                {{- range first 3 . -}}
+                {{- range . -}}
                   <span
                     class="fluidity-tag inline-flex items-center text-sm">
-                    {{- . -}}
+                    {{- .Title -}}
                   </span>
                 {{- end -}}
               </div>
@@ -56,7 +56,7 @@
         <!-- Date -->
         <time
           datetime="{{- .PublishDate.Format "2006-01-02" -}}"
-          class="text-base font-normal 
+          class="text-base font-normal
                 text-neutral-500 dark:text-neutral-400
                 whitespace-nowrap italic
                 group-hover:text-sky-600 dark:group-hover:text-sky-400

--- a/layouts/partials/archive-article.html
+++ b/layouts/partials/archive-article.html
@@ -28,17 +28,14 @@
           <div class="flex flex-col sm:flex-row items-start sm:items-center flex-wrap gap-x-3 gap-y-2">
             <!-- Categories -->
             {{- with $article.GetTerms "categories" -}}
-              {{- range . -}}
-                <span
-                  class="
-                  inline-flex py-1.5 px-1 text-sm
-                  text-sky-700 dark:text-sky-300
-                  underline underline-offset-4 decoration-sky-700
-                  transform transition-all duration-300
-                  group-hover:decoration-double">
-                  {{- .Title -}}
-                </span>
-              {{- end -}}
+              <div class="flex flex-wrap gap-2">
+                {{- range . -}}
+                  <span
+                    class="fluidity-category inline-flex items-center text-sm">
+                    {{- .Title -}}
+                  </span>
+                {{- end -}}
+              </div>
             {{- end -}}
             <!-- Tags -->
             {{- with $article.GetTerms "tags" -}}

--- a/layouts/partials/article-metadata.html
+++ b/layouts/partials/article-metadata.html
@@ -88,7 +88,7 @@
             {{- range . -}}
               <a
                 href="{{ .RelPermalink }}"
-                class="text-sm underline underline-offset-2 group-hover:text-sky-600 dark:group-hover:text-sky-400
+                class="text-sm underline underline-offset-2 hover:text-sky-600 dark:hover:text-sky-400
                       transition-colors duration-200">
                 {{ .LinkTitle }}
               </a>

--- a/layouts/partials/article-metadata.html
+++ b/layouts/partials/article-metadata.html
@@ -77,7 +77,7 @@
         </span>
       </div>
 
-      {{- if .Params.categories -}}
+      {{- with .GetTerms "categories" -}}
         <div class="flex items-center gap-2 group">
           <span
             class="text-sky-600 dark:text-sky-400 transition-transform duration-300
@@ -85,12 +85,12 @@
             {{- partial "utils/icon.html" (dict "icon" "folder") -}}
           </span>
           <div class="flex gap-2">
-            {{- range .Params.categories -}}
+            {{- range . -}}
               <a
-                href="{{ (site.GetPage (printf "/categories/%s" (. | urlize))).RelPermalink }}"
+                href="{{ .RelPermalink }}"
                 class="text-sm underline underline-offset-2 group-hover:text-sky-600 dark:group-hover:text-sky-400
                       transition-colors duration-200">
-                {{ . }}
+                {{ .LinkTitle }}
               </a>
             {{- end -}}
           </div>


### PR DESCRIPTION
Fixes a few issues related to pages with multiple terms:

- Fix hover highlighting on page when multiple categories are assigned (previously hovering over one of the links would highlight all of them in blue)
 
    ![image](https://github.com/user-attachments/assets/22126b02-61d5-4ae1-b8d8-73790cd871f4)

- Add site param for number of categories displayed on list pages (previously fixed at 1)
- Add site param for number of tags displayed on list pages (previously fixed at 3)

Also generating the category lists have been modified to use `GetTerms` to obtain link and text, and summaries have been added to the list pages (a site param could be added for this).

The use of `plainify` was required on my test site. I believe the summary was truncating in the middle of an element. This was causing style issues in the list. Given the summary code was copied from the home page, the same may need to be applied there.